### PR TITLE
corrected CPU compatibility issue.

### DIFF
--- a/sam3/drivers.py
+++ b/sam3/drivers.py
@@ -135,7 +135,7 @@ class Sam3ImageDriver:
             #           bf16 math via VNNI or software fallback — still faster than
             #           fp32 due to halved memory bandwidth.
             # Only skip for very old CPUs (SSE-only / pre-Haswell "DEFAULT" tier).
-            if cpu_cap in ("AVX512", "AVX2"):
+            if cpu_cap in ("AVX512",):
                 torch.autocast("cpu", dtype=torch.bfloat16).__enter__()
                 logger.info(f"CPU bfloat16 autocast ENABLED (capability: {cpu_cap})")
             else:
@@ -569,7 +569,7 @@ class Sam3VideoDriver:
             #           bf16 math via VNNI or software fallback — still faster than
             #           fp32 due to halved memory bandwidth.
             # Only skip for very old CPUs (SSE-only / pre-Haswell "DEFAULT" tier).
-            if cpu_cap in ("AVX512", "AVX2"):
+            if cpu_cap in ("AVX512",):
                 torch.autocast("cpu", dtype=torch.bfloat16).__enter__()
                 logger.info(f"CPU bfloat16 autocast ENABLED (capability: {cpu_cap})")
             else:


### PR DESCRIPTION
## Description

<!-- Describe what this PR does and why. Link to any related issue(s). -->

it fixes the issue of slow inference on AVX2 CPUs that do not support bfloat16

Closes #

## Type of change


<!-- Check the relevant option(s). -->

- [ ✓] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / code cleanup
- [ ] CI / build / tooling

## How has this been tested?

<!-- Describe the tests you ran and how to reproduce. -->

ran inference using video_prompter,py 

- [ ] `uv run python -m pytest tests/ -v` — all tests pass
- [ ] Manual testing (describe below)

**Test details:**


## Checklist

- [ ] My code follows the project's coding standards.
- [ ] I have added/updated tests for new or changed functionality.
- [ ] I have updated the documentation (README, docstrings) as needed.
- [ ] My changes generate no new warnings or errors.
- [ ] I have checked that there are no merge conflicts with `main`.

## Screenshots / output (if applicable)

<!-- Add screenshots, terminal output, or result comparisons. -->
